### PR TITLE
Decrease size of selector and make it mobile responsive

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -14,3 +14,14 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
+
+#root > div > main > div > div > div > div > div > div:nth-child(1) {
+  width: 50%;
+  height: auto;
+}
+
+@media (max-width: 768px) {
+  #root > div > main > div > div > div > div > div > div:nth-child(1) {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
Decrease the size of the selector `#root > div > main > div > div > div > div > div > div:nth-child(1)` and make it mobile responsive.

* Add CSS rules to decrease the width to 50% and set height to auto.
* Add media queries to adjust the width to 100% on screens with a maximum width of 768px.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/xenycx/project-books/pull/2?shareId=0ad48390-afe6-405a-9881-6618f68ca02b).